### PR TITLE
Fix division by zero if charging or discharging with no energy_rate

### DIFF
--- a/battery/src/platform/traits.rs
+++ b/battery/src/platform/traits.rs
@@ -46,8 +46,12 @@ pub trait BatteryDevice: Sized {
     // it would be easier and cheaper to return them instead of making some calculations
 
     fn time_to_full(&self) -> Option<Duration> {
+        let energy_rate = self.energy_rate();
         match self.state() {
-            State::Charging => {
+            // In some cases energy_rate can be 0 while Charging, for example just after
+            // plugging in the charger. Assume that the battery doesn't have time_to_full in such
+            // cases, to avoid divison by zero. See https://github.com/svartalf/rust-battery/pull/5
+            State::Charging if energy_rate != 0 => {
                 // Some drivers might report that `energy_full` is lower than `energy`,
                 // but battery is still charging. What should we do in that case?
                 // As for now, assuming that battery is fully charged, since we can't guess,
@@ -56,8 +60,7 @@ pub trait BatteryDevice: Sized {
                     Some(value) => value,
                     None => return None,
                 };
-                // TODO: Possible division by zero
-                let time_to_full = 3600 * energy_left / self.energy_rate();
+                let time_to_full = 3600 * energy_left / energy_rate;
                 if time_to_full > (20 * 60 * 60) {
                     None
                 } else {
@@ -69,10 +72,13 @@ pub trait BatteryDevice: Sized {
     }
 
     fn time_to_empty(&self) -> Option<Duration> {
+        let energy_rate = self.energy_rate();
         match self.state() {
-            State::Discharging => {
-                // TODO: Possible division by zero
-                let time_to_empty = 3600 * self.energy() / self.energy_rate();
+            // In some cases energy_rate can be 0 while Discharging, for example just after
+            // unplugging the charger. Assume that the battery doesn't have time_to_empty in such
+            // cases, to avoid divison by zero. See https://github.com/svartalf/rust-battery/pull/5
+            State::Discharging if energy_rate != 0 => {
+                let time_to_empty = 3600 * self.energy() / energy_rate;
                 if time_to_empty > (240 * 60 * 60) { // Ten days for discharging
                     None
                 } else {


### PR DESCRIPTION
When using battery-cli and unplugging the charger a division by zero happens because the battery is now in `State::Discharging`, but `energy_rate` is still 0.