### PR TITLE
Fix multiplication overflow for macos

### DIFF
--- a/battery/src/platform/macos/device.rs
+++ b/battery/src/platform/macos/device.rs
@@ -125,7 +125,7 @@ impl BatteryDevice for IoKitDevice {
     }
 
     fn percentage(&self) -> f32 {
-        (100 * self.energy() / self.energy_full()) as f32
+        100.0f32 * ((self.energy() as f32) / (self.energy_full() as f32))
     }
 
     fn state(&self) -> State {


### PR DESCRIPTION
The multiplication in `percentage` overflowed the u32 integer type before multiplication. Before, the operator precedence multiplied `self.energy()` by 100 which overflowed. The fix converts the energy and energy_full to floats and computes the ratio, before multiplying by 100 which prevents the overflow.