### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,20 @@ battery = "0.7.4"
 ## Examples
 
 ```rust
-let manager = battery::Manager::new()?;
+fn main() -> Result<(), battery::Error> {
+    let manager = battery::Manager::new()?;
 
-for battery in manager.batteries()? {
-    println!("Vendor: {:?}", battery.vendor());
-    println!("Model: {:?}", battery.model());
-    println!("State: {:?}", battery.state());
-    println!("Time to full charge: {:?}", battery.time_to_charge());
+    for (idx, maybe_battery) in manager.batteries()?.enumerate() {
+        let battery = maybe_battery?;
+        println!("Battery #{}:", idx);
+        println!("Vendor: {:?}", battery.vendor());
+        println!("Model: {:?}", battery.model());
+        println!("State: {:?}", battery.state());
+        println!("Time to full charge: {:?}", battery.time_to_full());
+        println!("");
+    }
+
+    Ok(())
 }
 ```
 


### PR DESCRIPTION
The README example doesn't seem to work:

- `Manager.batteries()` returns an iterator over `Result<Battery>`, not over Battery, so it was missing a ?
- it called `time_to_charge()` not `time_to_full()`

I also tidied it up a bit so you can paste it straight into a main.rs to try out the library.