### PR TITLE
Fix compilation failure in latest nightly

### DIFF
--- a/battery/Cargo.toml
+++ b/battery/Cargo.toml
@@ -20,7 +20,7 @@ is-it-maintained-open-issues = { repository = "svartalf/rust-battery" }
 [dependencies]
 cfg-if = "0.1"
 num-traits = { version = "0.2", default_features = false }
-uom = { version = "0.29", features = ["autoconvert", "f32", "si"] }
+uom = { version = "0.30", features = ["autoconvert", "f32", "si"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 lazycell = "~1.3"


### PR DESCRIPTION
Hey, currently your crate in version 0.7.6 fails to build in latest nightly because it requires uom in version 0.29 (see https://github.com/iliekturtles/uom/issues/210).

BTW: You forgot to add a tag for the 0.7.6 release in your git history :)
