### PR TITLE
Update nix to ~0.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.36.0  # MSRV
+          - 1.46.0  # MSRV
         arch:
           - i686-unknown-linux-gnu
           - x86_64-unknown-linux-gnu
@@ -51,7 +51,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.36.0  # MSRV
+          - 1.46.0  # MSRV
         arch:
           - i686-pc-windows-msvc
           - x86_64-pc-windows-msvc
@@ -92,7 +92,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.36.0  # MSRV
+          - 1.46.0  # MSRV
         arch:
           - x86_64-apple-darwin
     steps:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Latest Version](https://img.shields.io/crates/v/battery.svg)](https://crates.io/crates/battery)
 [![Latest Version](https://docs.rs/battery/badge.svg)](https://docs.rs/battery)
 [![Build Status](https://github.com/svartalf/rust-battery/workflows/Continuous%20integration/badge.svg)](https://github.com/svartalf/rust-battery/actions?workflow=Continuous+integration)
-![Minimum rustc version](https://img.shields.io/badge/rustc-1.36+-yellow.svg)
+![Minimum rustc version](https://img.shields.io/badge/rustc-1.46+-yellow.svg)
 ![Apache 2.0 OR MIT licensed](https://img.shields.io/badge/license-Apache2.0%2FMIT-blue.svg)
 [![Backers on Open Collective](https://opencollective.com/rust-battery/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/rust-battery/sponsors/badge.svg)](#sponsors)
@@ -46,7 +46,7 @@ might be automatically rejected by Apple based on that fact. Use it on your own 
 
 ## Install
 
-As a prerequisite, `battery` crate requires at least Rustc version **1.36** or greater.
+As a prerequisite, `battery` crate requires at least Rustc version **1.46** or greater.
 
 Add the following line into a `Cargo.toml`:
 

--- a/battery/Cargo.toml
+++ b/battery/Cargo.toml
@@ -35,7 +35,7 @@ winapi = { version ="~0.3", features = ["impl-default", "devguid", "winbase", "i
 
 [target.'cfg(any(target_os = "dragonfly", target_os = "freebsd"))'.dependencies]
 libc = "~0.2"
-nix = "~0.19"
+nix = "~0.23"
 
 [dev-dependencies]
 tempfile = "^3.0"

--- a/battery/src/errors.rs
+++ b/battery/src/errors.rs
@@ -85,24 +85,10 @@ mod nix_impl {
     use super::Error;
 
     impl From<nix::Error> for Error {
-        fn from(e: nix::Error) -> Self {
-            match e {
-                nix::Error::Sys(errno) => Error {
-                    source: io::Error::from_raw_os_error(errno as i32),
-                    description: Some(errno.desc().into()),
-                },
-                nix::Error::InvalidPath => Error {
-                    source: io::Error::new(io::ErrorKind::InvalidInput, e),
-                    description: Some("Invalid path".into()),
-                },
-                nix::Error::InvalidUtf8 => Error {
-                    source: io::Error::new(io::ErrorKind::InvalidData, e),
-                    description: Some("Invalid UTF-8 string".into()),
-                },
-                nix::Error::UnsupportedOperation => Error {
-                    source: io::Error::new(io::ErrorKind::Other, e),
-                    description: Some("Unsupported operation".into()),
-                },
+        fn from(errno: nix::Error) -> Self {
+            Error {
+                source: io::Error::from_raw_os_error(errno as i32),
+                description: Some(errno.desc().into()),
             }
         }
     }


### PR DESCRIPTION
`nix` has recently published a security advisory (RUSTSEC-2021-0119) and the `nix` version used in `rust-battery` is vulnerable. This PR updates nix (and MSRV) to the latest version and  makes the necessary changes to have it successfully build for FreeBSD with `cross`.
Closes #89